### PR TITLE
added setEncoding to request

### DIFF
--- a/lib/webDriver.js
+++ b/lib/webDriver.js
@@ -165,6 +165,7 @@ WebDriver.prototype._cmd = function(params, callback) {
 function request(params, callback) {
 	var req = http.request(params, function(res) {
 		var data = '';
+		res.setEncoding('utf8');
 		res.on('data', function(chunk) { data += chunk; });
 		res.on('end', function() {
 			res.data = data;


### PR DESCRIPTION
I add line `res.setEncoding('utf8');` to `request` function because sometimes response contains broken chars without this line.
